### PR TITLE
Fix Ollama configuration by allowing port number in URL

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -278,6 +278,6 @@ async function generateCommitMessages(diff: string, prevCommit: string): Promise
 }
 
 function isURL(string: string): boolean {
-    const urlRegex = /^(https?:\/\/)?(www\.)?([a-zA-Z0-9\-\.]+\.)+([a-zA-Z0-9\-\/]+)([/?#]*)*$/;
+    const urlRegex = /^(https?:\/\/)?(www\.)?([a-zA-Z0-9\-\.]+\.)+([a-zA-Z0-9\-\/]+)(:[0-9]+)?([/?#]*)*$/;
     return urlRegex.test(string);
 }


### PR DESCRIPTION
Configuring Ollama with providerUrl http://localhost:11434/ was failing with the following error message:

```
Url provider is broken! Please run 'commitah --config-update' and re-config again.
```

This PR fixes the Regex for the URL